### PR TITLE
Refactor middleware to stop execution after calling `next()` when `continueMiddleware` is true

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,10 +93,8 @@ const options = {
 (_type: boolean default: false_)
 
   The `authorize()` and `token()` middlewares will both render their 
-  result to the response and end the pipeline.
-  next() will only be called if this is set to true.
-
-  **Note:** You cannot modify the response since the headers have already been sent.
+  result to the response and end the pipeline **unless** this is set to true,
+  then only next() will be called.
 
   `authenticate()` does not modify the response and will always call next()
 

--- a/index.js
+++ b/index.js
@@ -49,9 +49,7 @@ class ExpressOAuthServer {
    * @param options.useErrorHandler {boolean=} If false, an error response will be rendered by this component.
    *   Set this value to true to allow your own express error handler to handle the error.
    * @param options.continueMiddleware {boolean=} The `authorize()` and `token()` middlewares will both render their
-   *   result to the response and end the pipeline.
-   *   next() will only be called if this is set to true.
-   *   **Note:** You cannot modify the response since the headers have already been sent.
+   *   result to the response and end the pipeline unless this is set to true, then only next() will be called.
    *   `authenticate()` does not modify the response and will always call next()
    */
   constructor(options = {}) {
@@ -121,7 +119,7 @@ class ExpressOAuthServer {
 
       res.locals.oauth = { code };
       if (this.continueMiddleware) {
-        next();
+        return next();
       }
 
       return handleResponse.call(this, req, res, response);
@@ -154,7 +152,7 @@ class ExpressOAuthServer {
 
       res.locals.oauth = { token };
       if (this.continueMiddleware) {
-        next();
+        return next();
       }
 
       return handleResponse.call(this, req, res, response);


### PR DESCRIPTION
### Description: ###

This was the main reason I've forked this library.

Normally when we set the `continueMiddleware` to `true` on this wrapper, it calls `next()`, but still keeps executing code until it calls `res.send()`, making it impossible to customize the response.

So in order to make it possible, I refactored the middleware to stop execution after calling `next()` when `continueMiddleware` is true by adding a `return` statement.
