### PR TITLE
Move `continueMiddleware` option into middlewares

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,6 @@ app.listen(3000);
 ```
 const options = { 
   useErrorHandler: false, 
-  continueMiddleware: false,
 }
 ```
 
@@ -88,6 +87,14 @@ const options = {
 
   If false, an error response will be rendered by this component.
   Set this value to true to allow your own express error handler to handle the error.
+
+## Extra options for token and authorize middlewares
+
+```
+const options = { 
+  continueMiddleware: false, 
+}
+```
 
 - `continueMiddleware`
 (_type: boolean default: false_)

--- a/index.d.ts
+++ b/index.d.ts
@@ -10,7 +10,6 @@ import * as OAuth2Server from "@node-oauth/oauth2-server";
 declare namespace ExpressOAuthServer {
   interface Options extends OAuth2Server.ServerOptions {
     useErrorHandler?: boolean | undefined;
-    continueMiddleware?: boolean | undefined;
   }
 }
 
@@ -28,7 +27,9 @@ declare class ExpressOAuthServer {
   ) => Promise<OAuth2Server.Token>;
 
   authorize(
-    options?: OAuth2Server.AuthorizeOptions
+    options?: OAuth2Server.AuthorizeOptions & {
+      continueMiddleware?: boolean | undefined;
+    }
   ): (
     request: express.Request,
     response: express.Response,
@@ -36,7 +37,9 @@ declare class ExpressOAuthServer {
   ) => Promise<OAuth2Server.AuthorizationCode>;
 
   token(
-    options?: OAuth2Server.TokenOptions
+    options?: OAuth2Server.TokenOptions & {
+      continueMiddleware?: boolean | undefined;
+    }
   ): (
     request: express.Request,
     response: express.Response,


### PR DESCRIPTION
### Description: ###

Since `continueMiddleware` will now stop the execution at `next()`, I made it so it can only be enabled on the `token` and `authorize` middlewares
